### PR TITLE
Remove + char from phone number to use as sip rule name

### DIFF
--- a/src/createChimeSMAResources/createChimeSMAResources.py
+++ b/src/createChimeSMAResources/createChimeSMAResources.py
@@ -91,7 +91,7 @@ def on_create(event):
 
     new_phone_number = get_phone_number()
     sma_ID = create_SMA(region, name, lambdaArn)
-    rule_name = str(new_phone_number)
+    rule_name = str(new_phone_number).replace("+", "")
     sip_rule_response = create_sip_rule(rule_name, new_phone_number, sma_ID, region)
     create_SMA_response = {"smaID": sma_ID, "phoneNumber": new_phone_number}
     return {"PhysicalResourceId": physical_id, "Data": create_SMA_response}


### PR DESCRIPTION
When deploying the sample, I got an error saying that the name for the sip rule is not valid:
![image](https://user-images.githubusercontent.com/75750855/226986062-7a7e1810-d816-4821-936f-e4af4109aadb.png)


To solve this, this PR removes the + character from the phone number string to be used as SIP rule name.
