### PR TITLE
fix: CFT fails to deploy (... nodejs12.x is no longer supported for creating or updating AWS Lambda functions) #2

### DIFF
--- a/bin/call-forwarding-with-sma.ts
+++ b/bin/call-forwarding-with-sma.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import "source-map-support/register";
-import * as cdk from "@aws-cdk/core";
+import * as cdk from "aws-cdk-lib";
 import { CallForwardingWithSMA } from "../lib/call-forwarding-with-sma-stack";
 
 const app = new cdk.App();

--- a/cdk.json
+++ b/cdk.json
@@ -2,16 +2,9 @@
   "app": "npx ts-node --prefer-ts-exts bin/call-forwarding-with-sma.ts",
   "context": {
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
     "@aws-cdk/core:stackRelativeExports": "true",
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
     "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
     "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
     "@aws-cdk/aws-lambda:recognizeVersionProps": true
   }
 }

--- a/lib/call-forwarding-with-sma-stack.ts
+++ b/lib/call-forwarding-with-sma-stack.ts
@@ -1,15 +1,16 @@
-import * as cdk from "@aws-cdk/core";
-import dynamodb = require("@aws-cdk/aws-dynamodb");
-import iam = require("@aws-cdk/aws-iam");
-import lambda = require("@aws-cdk/aws-lambda");
-import custom = require("@aws-cdk/custom-resources");
-import { CustomResource, Duration } from "@aws-cdk/core";
-import apigateway = require("@aws-cdk/aws-apigateway");
-import s3 = require("@aws-cdk/aws-s3");
-import s3deploy = require("@aws-cdk/aws-s3-deployment");
+import * as cdk from "aws-cdk-lib";
+import { Construct } from "constructs";
+import dynamodb = require("aws-cdk-lib/aws-dynamodb");
+import iam = require("aws-cdk-lib/aws-iam");
+import lambda = require("aws-cdk-lib/aws-lambda");
+import custom = require("aws-cdk-lib/custom-resources");
+import { CustomResource, Duration } from "aws-cdk-lib/core";
+import apigateway = require("aws-cdk-lib/aws-apigateway");
+import s3 = require("aws-cdk-lib/aws-s3");
+import s3deploy = require("aws-cdk-lib/aws-s3-deployment");
 
 export class CallForwardingWithSMA extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const outgoingWav = new s3.Bucket(this, "outgoingWav", {

--- a/package.json
+++ b/package.json
@@ -10,20 +10,15 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "1.131.0",
     "@types/node": "16.11.0",
-    "aws-cdk": "1.131.0",
+    "aws-cdk-lib": "2.81.0",
     "ts-node": "^10.3.0",
-    "typescript": "~4.4.4"
+    "typescript": "~4.4.4",
+    "constructs": "^10.0.0"
   },
   "dependencies": {
-    "@aws-cdk/aws-apigateway": "1.131.0",
-    "@aws-cdk/aws-dynamodb": "1.131.0",
-    "@aws-cdk/aws-iam": "1.131.0",
-    "@aws-cdk/aws-lambda": "1.131.0",
-    "@aws-cdk/aws-s3-deployment": "1.131.0",
-    "@aws-cdk/core": "1.131.0",
-    "@aws-cdk/custom-resources": "1.131.0",
-    "source-map-support": "^0.5.20"
+    "aws-cdk-lib": "2.81.0",
+    "source-map-support": "^0.5.20",
+    "constructs": "^10.0.0"
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Fixes #2 

*Description of changes:*
updated to use AWS-SDK v2 instead of v1. Migration process was followed from here (https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
